### PR TITLE
fix(auth): correct sign-in/sign-up public route typo causing redirect…

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,12 @@ import { NextResponse } from "next/server";
 import { getAllowedRoles } from "@/lib/rbac/route-guards";
 import type { RoleName } from "@/lib/rbac/permissions";
 
-const isPublicRoute = createRouteMatcher(["/sing-in", "/sing-up", "/", "/api/webhooks/(.*)"]);
+const isPublicRoute = createRouteMatcher([
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/",
+  "/api/webhooks/(.*)",
+]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (isPublicRoute(req)) return;


### PR DESCRIPTION
… loop

The middleware marked "/sing-in" and "/sing-up" (typo, missing 'g') as public routes, so the real "/sign-in" was protected by auth.protect() and redirected to itself — an infinite redirect loop for unauthenticated users. Fixed to "/sign-in(.*)" and "/sign-up(.*)" to also cover Clerk's nested verification routes.