### PR TITLE
Actualización del módulo de Ayuda: aprobación cliente y paginación

### DIFF
--- a/.taskapp-cli-manifest.json
+++ b/.taskapp-cli-manifest.json
@@ -1,0 +1,183 @@
+{
+  "version": "0.2.0",
+  "updatedAt": "2026-06-10T00:10:52.356Z",
+  "files": {
+    "src\\features\\Ayuda\\actions\\support-approval.ts": {
+      "hash": "3b28452058e4702094cbd939cc0f9903496230fc3d3ca9252459798c2ff67dfb"
+    },
+    "src\\features\\Ayuda\\actions\\support-attachments.ts": {
+      "hash": "5919a05d9d088e00286899e7235fde3e873fccf4c5bea60bd590321bc527dfe0"
+    },
+    "src\\features\\Ayuda\\actions\\support-comments.ts": {
+      "hash": "3fb7ea35013f69c99baf459970b1e241eaf17cc1d0e686e6a349debf0cc519a8"
+    },
+    "src\\features\\Ayuda\\actions\\support-reopen.ts": {
+      "hash": "b7bc1742aca44972268d3d80dfd1d141792f5c9ff9171690b411480aab7419a2"
+    },
+    "src\\features\\Ayuda\\actions\\support-ticket-views.ts": {
+      "hash": "b070c3be32cd8ed5cab9b88a1318c5d45cebc44866a5e443fe8b20bcce82c94d"
+    },
+    "src\\features\\Ayuda\\actions\\support-tickets.ts": {
+      "hash": "fddea0eca5a2e552b865098291a205c54329a7031b65962567c1a501d39a13a0"
+    },
+    "src\\features\\Ayuda\\components\\ApproverAllTickets.tsx": {
+      "hash": "d5024f8f232721e585f852f8161d8094caba2f384696b63dd71e8e7bc6db9d23"
+    },
+    "src\\features\\Ayuda\\components\\ApproverInbox.tsx": {
+      "hash": "4a6e85902e634a27e926f16a71ed3fa983b178eb1cbaab27706fa1c1a4b22337"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketApprovalBanner.tsx": {
+      "hash": "49bd07f49e727d9cf5f021a47747642881de2a8817ca6e53223628a549fa91a1"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketAttachmentsList.tsx": {
+      "hash": "df53e558c56296fc0f53177d7d2788295c122639f176c0d06c411f9150b0c54b"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketCommentComposer.tsx": {
+      "hash": "f870f588401d1699c727140f3162043d82b31f213009a85a10ac994c571f56c2"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketCommentItem.tsx": {
+      "hash": "6e2e75037a2ffc7945b9a9e5660543f6b913179210c3a0122457d15801fcb06b"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketCommentsThread.tsx": {
+      "hash": "826154af8715448fe8d0edebb7b60c7501d3bee3975e7a903ac2dff905ae510d"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketDetailBody.tsx": {
+      "hash": "2fb9cffa418748adb9294c8fd078ab27627d3674dffc13a2a347d4ec69c694b4"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketDetailHeader.tsx": {
+      "hash": "e9fe971224b6c1046b9b523fdc96a1150521ef35c3dc7254ff960d9497b68792"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketDetailSheet.tsx": {
+      "hash": "038bcaca3766aced270b95169b46283ec827d4ff4fb33f2e41a4d3ee95e23c84"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketReopenRequestBanner.tsx": {
+      "hash": "8b2f26af556f3a58b6a2f411f66173bf3a7563c2461a673c117df0ad48238410"
+    },
+    "src\\features\\Ayuda\\components\\detail\\TicketReopenRequestDialog.tsx": {
+      "hash": "12db260fe89fbd0c09e67fff93355777995f23f6fa287c9d47e6134a5c68fc17"
+    },
+    "src\\features\\Ayuda\\components\\EmptyTicketsState.tsx": {
+      "hash": "e8b17fb415e147ff3d1f756e4c0051c8121300ecb8502dd8cc8b8d0709ba3e6f"
+    },
+    "src\\features\\Ayuda\\components\\HelpCenter.tsx": {
+      "hash": "2bd100faa021647f986023ef1c4b5542251bd4d3c9cfad9ce59b3825597a1444"
+    },
+    "src\\features\\Ayuda\\components\\MyTicketsList.tsx": {
+      "hash": "fb813cd564b9171864ac1afe2250c6266f603884a1842724d2d8d87332c9bfc3"
+    },
+    "src\\features\\Ayuda\\components\\PaginationNav.tsx": {
+      "hash": "32ca75c80cb21887bf78659c883aaf12a91dd2e3992cd679a60a616fd447948a"
+    },
+    "src\\features\\Ayuda\\components\\SupportTicketsRealtimeProvider.tsx": {
+      "hash": "88df108dedeb6ba35d25c2a5d44f012fcdd4dc780ff667f890751632bd66ff0e"
+    },
+    "src\\features\\Ayuda\\components\\TicketAttachmentInput.tsx": {
+      "hash": "e86f37d60775a53be7f3e1bfc848d91e98d8ad650169e0099822bb86c3504da6"
+    },
+    "src\\features\\Ayuda\\components\\TicketCard.tsx": {
+      "hash": "44b66e300e2378de3ec00f5d91ce340d4ef86ab5411a2741d6ed5837b86fb3fe"
+    },
+    "src\\features\\Ayuda\\components\\TicketCategoryBadge.tsx": {
+      "hash": "deb08dee4c5f053764de414fb101a01150310fbaf0fd91efadd9b18e5f8fec2f"
+    },
+    "src\\features\\Ayuda\\components\\TicketForm.tsx": {
+      "hash": "dcc3bfb6c9fee7c3ab5d44002423a345330c74cab2a1e5d9f880854c11fb90aa"
+    },
+    "src\\features\\Ayuda\\components\\TicketPriorityBadge.tsx": {
+      "hash": "63be4644be782c2f2c0fde6e72057dbab058f9819116a6d889dd46291af00d91"
+    },
+    "src\\features\\Ayuda\\components\\TicketPrioritySelect.tsx": {
+      "hash": "2e13d17f7f1a1e4c0ce8a75a105932debb2bee3a50242e8b0bee9e97a17f5537"
+    },
+    "src\\features\\Ayuda\\components\\TicketStatusBadge.tsx": {
+      "hash": "b9b844eb0fab4f5cfc0fa1518cc528e868c03f7124be95f0d96369fc9e3eded0"
+    },
+    "src\\features\\Ayuda\\constants\\categories.ts": {
+      "hash": "0e375a577a21d64b998350db9e16da5759fb1bc6a4a45b8e782bd6c429ebce65"
+    },
+    "src\\features\\Ayuda\\constants\\ticket-priority.ts": {
+      "hash": "8cc026471056501e559a9de7d5fa02d6eea4d17c08f3a923f007c88d0f304efb"
+    },
+    "src\\features\\Ayuda\\constants\\ticket-status.ts": {
+      "hash": "d0f06c82bd725ce026e72c0e2499702c32109a62376c56e1aeb6a8751b7fd7bb"
+    },
+    "src\\features\\Ayuda\\fallback\\ApproverAllTicketsSkeleton.tsx": {
+      "hash": "7c0f6b9547adb48f6f730a80001e06f4e5f6954877493117aa7f121d0a694e88"
+    },
+    "src\\features\\Ayuda\\fallback\\ApproverInboxSkeleton.tsx": {
+      "hash": "cf2260ad80e2314a19778d332f2fc8f954a6c8babb424e55464da9458ef8546d"
+    },
+    "src\\features\\Ayuda\\fallback\\MyTicketsListSkeleton.tsx": {
+      "hash": "6a6a9c3237f2d59cd60c784f6762fdd370d6dd43298886cb2bd4e8e2326dc359"
+    },
+    "src\\features\\Ayuda\\fallback\\TicketCommentsThreadSkeleton.tsx": {
+      "hash": "46a8d3e420dd1e83e6035372fd4e0347f1f5811c4f46f4883d3e5925e2a3c0e8"
+    },
+    "src\\features\\Ayuda\\fallback\\TicketDetailSheetSkeleton.tsx": {
+      "hash": "82c16b6b379156926388904c0e9279a4196d137a79e9efdbc7543ef561c27cd2"
+    },
+    "src\\features\\Ayuda\\hooks\\queryKeys.ts": {
+      "hash": "4fe9db7addb50bf53cbff8c9719bb371b1b51d3f328be472261a73c7e3b8d52a"
+    },
+    "src\\features\\Ayuda\\hooks\\useApproverTickets.ts": {
+      "hash": "da0d7d417c7233da7f737420397353d6d21bc4d0e7286dd411a9b651b9821b7a"
+    },
+    "src\\features\\Ayuda\\hooks\\useApproveTicket.ts": {
+      "hash": "dad2ef218910df5599cdd57abecb4fd6e379eef7b8104536a3cc8a0b5a2374fe"
+    },
+    "src\\features\\Ayuda\\hooks\\useCreateComment.ts": {
+      "hash": "f982b36acb0b71ff5c0b05bf76ba98fe8101fd8dfa8ca5f82ba49eb91362dd69"
+    },
+    "src\\features\\Ayuda\\hooks\\useCreateTicket.ts": {
+      "hash": "903c414b5c3156a81fb4c0eab39e84de6f0433758982dc2473bef791a69a311d"
+    },
+    "src\\features\\Ayuda\\hooks\\useMarkTicketAsReadMutation.ts": {
+      "hash": "528d17693e504deccac56be1b8977fcc9773d10b85e584007789b59f12351bff"
+    },
+    "src\\features\\Ayuda\\hooks\\useMyTickets.ts": {
+      "hash": "5853a494829816716ce5884e7574f930602bb0c7eb2325c05b49143e09ed41fd"
+    },
+    "src\\features\\Ayuda\\hooks\\useMyTicketsPage.ts": {
+      "hash": "7236ce7a81cbce7ad89f65ad9c08e1fbb02ca731b189a8afe5225ddecd45c794"
+    },
+    "src\\features\\Ayuda\\hooks\\useMyTicketsWithUnread.ts": {
+      "hash": "536c4971f7861d52c783bfff935a54b7a58c045e368533f6e7f407e483fbfcee"
+    },
+    "src\\features\\Ayuda\\hooks\\useRejectTicket.ts": {
+      "hash": "879855ef4481d25b068f6066390eda18270ca0ccbcb9cbe83f7075ff1b47260e"
+    },
+    "src\\features\\Ayuda\\hooks\\useRequestTicketReopen.ts": {
+      "hash": "1739f8a063b482308e2b038702f99a91124d88debfe6e474f6af096cbe0adc26"
+    },
+    "src\\features\\Ayuda\\hooks\\useSupportTicketsRealtimeSync.ts": {
+      "hash": "70b338417158a10a564b5fb33a4c9b5867180f6430275e88150cb5e4eb7227bc"
+    },
+    "src\\features\\Ayuda\\hooks\\useTicketComments.ts": {
+      "hash": "3ec2ce8c76aaa8107c00d56c100d25b8547eae723587460be40f21aea6e1c7b4"
+    },
+    "src\\features\\Ayuda\\hooks\\useTicketDetail.ts": {
+      "hash": "3270ad84fcca0a14756dbbf29bd708189b1ab650983b07609894f83bd64046c0"
+    },
+    "src\\features\\Ayuda\\hooks\\useUnreadSupportTicketsCount.ts": {
+      "hash": "460b21124eda52771ddf69ee639ef9de6b56a873f57d0417b323d2340751cb41"
+    },
+    "src\\features\\Ayuda\\hooks\\useUploadAttachment.ts": {
+      "hash": "1a95c52ef4e9efee1237e62dc3736eb9148360bbde72d466a17faa51c117c1cc"
+    },
+    "src\\features\\Ayuda\\types\\index.ts": {
+      "hash": "a8961037e07cbb457b8a9a286235a0f92590428cae1becfc6d321331d9dd6246"
+    },
+    "src\\shared\\lib\\taskapp\\client.ts": {
+      "hash": "98fecba6008e342df4fffb2034f29fb3fc149a5c88700e3d6f5f55a2747d11b4"
+    },
+    "src\\shared\\lib\\taskapp\\errors.ts": {
+      "hash": "9a59555b47c444bea9988d6335d3610188b4bb32f56f6cf634a64b64c2bb18a6"
+    },
+    "src\\shared\\lib\\taskapp\\types.ts": {
+      "hash": "1732cc8a351a5a7ee2fb716b7835ea7c3765c9c0fbf1f588341221343900407b"
+    },
+    "src\\app\\api\\taskapp\\events\\route.ts": {
+      "hash": "3d6a0ebd4b2d013bd8e5c78d2ecdbabb1bb35afb42d85afba4fc530cab3670c1"
+    }
+  }
+}

--- a/src/features/Ayuda/actions/support-approval.ts
+++ b/src/features/Ayuda/actions/support-approval.ts
@@ -2,6 +2,7 @@
 
 import { Logger } from "@/lib/logger";
 import { taskAppClient } from "@/shared/lib/taskapp/client";
+import { TaskAppError } from "@/shared/lib/taskapp/errors";
 import type { Ticket } from "@/shared/lib/taskapp/types";
 import { getReporterEmail } from "./getReporterEmail";
 import { getSupportTicketById } from "./support-tickets";
@@ -17,18 +18,97 @@ async function assertCanApprove(
   const ticket = await getSupportTicketById(ticketId);
   if (!ticket) throw new Error("No tenés acceso a este ticket");
 
-  if (ticket.approver_email !== reporter.email) {
-    logger.warn("Usuario no es approver", {
-      data: { ticketId, user: reporter.email, approver: ticket.approver_email },
-    });
-    throw new Error("No sos el aprobador asignado a este ticket");
-  }
-
-  if (ticket.status?.slug !== "valued") {
-    throw new Error('El ticket no está en estado "Valuado"');
+  // La autorización fina (que el email sea uno de los aprobadores del proyecto)
+  // la hace el backend contra el array de aprobadores. Acá solo validamos que el
+  // ticket esté en el estado correcto para aprobar.
+  if (ticket.status?.slug !== "pendiente_aprobacion") {
+    throw new Error("Este ticket ya fue aprobado o rechazado por otro aprobador.");
   }
 
   return { approverEmail: reporter.email, ticket };
+}
+
+/**
+ * Traduce el error del backend a un mensaje accionable. El caso típico es la
+ * carrera entre aprobadores: el segundo recibe 400 "not pending" del server.
+ */
+function approvalError(error: unknown, fallback: string): Error {
+  if (
+    error instanceof TaskAppError &&
+    error.status === 400 &&
+    error.message.includes("not pending")
+  ) {
+    return new Error("Este ticket ya fue aprobado o rechazado por otro aprobador.");
+  }
+  return new Error(fallback);
+}
+
+/**
+ * Lista completa (sin paginar) de tickets visibles para el aprobador. Usada para
+ * chequeos de pertenencia (acceso al detalle). Si el usuario no es aprobador,
+ * el backend responde 403 y devolvemos lista vacía.
+ */
+export async function getTicketsForApprover(): Promise<Ticket[]> {
+  const reporter = await getReporterEmail();
+  if (!reporter) return [];
+  try {
+    return (await taskAppClient.listTicketsForApprover(reporter.email)).tickets;
+  } catch (error) {
+    logger.warn("No se pudo listar tickets del aprobador", {
+      data: { user: reporter.email, error },
+    });
+    return [];
+  }
+}
+
+export interface ApproverTicketsPage {
+  tickets: Ticket[];
+  total: number;
+}
+
+/**
+ * Página de tickets del proyecto para la vista auditora del aprobador
+ * (server-side, más recientes primero).
+ */
+export async function getApproverTicketsPage(
+  page: number,
+  pageSize: number
+): Promise<ApproverTicketsPage> {
+  const reporter = await getReporterEmail();
+  if (!reporter) return { tickets: [], total: 0 };
+  try {
+    const { tickets, total } = await taskAppClient.listTicketsForApprover(reporter.email, {
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+    });
+    return { tickets, total };
+  } catch (error) {
+    logger.warn("No se pudo listar la página de tickets del aprobador", {
+      data: { user: reporter.email, page, error },
+    });
+    return { tickets: [], total: 0 };
+  }
+}
+
+/**
+ * Tickets pendientes de aprobación del cliente (bandeja del aprobador y gate
+ * del banner de aprobación en el detalle).
+ */
+export async function getPendingApproverTickets(): Promise<Ticket[]> {
+  const reporter = await getReporterEmail();
+  if (!reporter) return [];
+  try {
+    const { tickets } = await taskAppClient.listTicketsForApprover(reporter.email, {
+      status: "pendiente_aprobacion",
+      limit: 100,
+    });
+    return tickets;
+  } catch (error) {
+    logger.warn("No se pudo listar pendientes del aprobador", {
+      data: { user: reporter.email, error },
+    });
+    return [];
+  }
 }
 
 export async function approveSupportTicket(ticketId: number): Promise<Ticket> {
@@ -38,7 +118,7 @@ export async function approveSupportTicket(ticketId: number): Promise<Ticket> {
     return await taskAppClient.approveTicket(ticketId, approverEmail);
   } catch (error) {
     logger.error("Error aprobando ticket", { data: { ticketId, error } });
-    throw new Error("No pudimos registrar la aprobación. Probá de nuevo.");
+    throw approvalError(error, "No pudimos registrar la aprobación. Probá de nuevo.");
   }
 }
 
@@ -49,6 +129,6 @@ export async function rejectSupportTicket(ticketId: number): Promise<Ticket> {
     return await taskAppClient.rejectTicket(ticketId, approverEmail);
   } catch (error) {
     logger.error("Error rechazando ticket", { data: { ticketId, error } });
-    throw new Error("No pudimos registrar el rechazo. Probá de nuevo.");
+    throw approvalError(error, "No pudimos registrar el rechazo. Probá de nuevo.");
   }
 }

--- a/src/features/Ayuda/actions/support-tickets.ts
+++ b/src/features/Ayuda/actions/support-tickets.ts
@@ -13,6 +13,10 @@ import { listSupportTicketComments } from "./support-comments";
 const logger = new Logger("features/Ayuda/support-tickets");
 const notifLogger = new Logger("features/Ayuda/notifications");
 
+// Estados terminales: en ellos no esperamos respuestas nuevas de agente, así que
+// se pueden omitir del fetch de comments para acotar llamadas a la API.
+const RESOLVED_STATUS_SLUGS = new Set(["resolved", "done", "closed", "cancelled"]);
+
 export async function createSupportTicket(input: CreateSupportTicketInput): Promise<Ticket> {
   const reporter = await getReporterEmail();
   if (!reporter) {
@@ -66,7 +70,7 @@ export async function getMySupportTickets(): Promise<Ticket[]> {
   if (!reporter) return [];
 
   try {
-    return await taskAppClient.listTicketsByReporter(reporter.email);
+    return (await taskAppClient.listTicketsByReporter(reporter.email)).tickets;
   } catch (error) {
     logger.error("Error listando tickets propios", { data: { error } });
     return [];
@@ -94,20 +98,22 @@ export async function getSupportTicketById(id: number): Promise<Ticket | null> {
   }
 
   const isReporter = ticket.reporter_email === reporter.email;
-  const isApprover = ticket.approver_email === reporter.email;
-  if (!isReporter && !isApprover) {
-    logger.warn("Acceso denegado al ticket", {
-      data: {
-        id,
-        user: reporter.email,
-        reporter: ticket.reporter_email,
-        approver: ticket.approver_email,
-      },
-    });
-    return null;
+  if (isReporter) return ticket;
+
+  // No es el reporter: puede verlo igual si es aprobador del proyecto. La
+  // autorización real la hace el backend: el listado for-approver solo devuelve
+  // tickets si el email está en el array de aprobadores (si no, 403 → []).
+  try {
+    const approverTickets = await taskAppClient.listTicketsForApprover(reporter.email);
+    if (approverTickets.tickets.some((t) => t.id === ticket.id)) return ticket;
+  } catch {
+    // no es aprobador — cae al deny de abajo
   }
 
-  return ticket;
+  logger.warn("Acceso denegado al ticket", {
+    data: { id, user: reporter.email, reporter: ticket.reporter_email },
+  });
+  return null;
 }
 
 /**
@@ -125,6 +131,50 @@ export async function getMyTicketsWithUnread(): Promise<TicketWithUnread[]> {
   const tickets = await getMySupportTickets();
   if (tickets.length === 0) return [];
 
+  return enrichWithUnread(tickets, reporter);
+}
+
+export interface MyTicketsPage {
+  tickets: TicketWithUnread[];
+  total: number;
+  completed: number;
+}
+
+/**
+ * Página de tickets del usuario (server-side, más recientes primero) enriquecida
+ * con no-leídos. `total`/`completed` vienen del backend sin paginar, para la
+ * navegación y las estadísticas.
+ */
+export async function getMyTicketsPageWithUnread(
+  page: number,
+  pageSize: number
+): Promise<MyTicketsPage> {
+  const reporter = await getReporterEmail();
+  if (!reporter) {
+    notifLogger.warn("No authenticated user, returning empty page");
+    return { tickets: [], total: 0, completed: 0 };
+  }
+
+  try {
+    const { tickets, total, completed } = await taskAppClient.listTicketsByReporter(
+      reporter.email,
+      {
+        limit: pageSize,
+        offset: (page - 1) * pageSize,
+      }
+    );
+    const enriched = tickets.length > 0 ? await enrichWithUnread(tickets, reporter) : [];
+    return { tickets: enriched, total, completed };
+  } catch (error) {
+    logger.error("Error listando página de tickets propios", { data: { page, error } });
+    return { tickets: [], total: 0, completed: 0 };
+  }
+}
+
+async function enrichWithUnread(
+  tickets: Ticket[],
+  reporter: NonNullable<Awaited<ReturnType<typeof getReporterEmail>>>
+): Promise<TicketWithUnread[]> {
   // Views del usuario (degrada elegante si la DB falla)
   let viewsMap = new Map<number, { lastSeenAt: Date; lastSeenStatusId: bigint }>();
   try {
@@ -149,11 +199,19 @@ export async function getMyTicketsWithUnread(): Promise<TicketWithUnread[]> {
     }));
   }
 
-  // Identificar tickets que requieren fetch de comments
+  // Identificar tickets que requieren fetch de comments.
+  // NO dependemos solo de updated_at: crear un comentario en el backend NO
+  // bumpea tasks.updated_at, así que filtrar por updated_at perdería las
+  // respuestas nuevas de agente. Traemos comments de los tickets sin view,
+  // de los actualizados, y de todos los que NO están resueltos (donde una
+  // respuesta de agente es esperable). Los resueltos se omiten para acotar
+  // llamadas a la API.
   const ticketsNeedingComments = tickets.filter((t) => {
     const view = viewsMap.get(t.id);
     if (!view) return true;
-    return new Date(t.updated_at) > view.lastSeenAt;
+    if (new Date(t.updated_at) > view.lastSeenAt) return true;
+    const slug = t.status?.slug;
+    return !slug || !RESOLVED_STATUS_SLUGS.has(slug);
   });
 
   // Fetch comments en paralelo con failure aislado

--- a/src/features/Ayuda/components/ApproverAllTickets.tsx
+++ b/src/features/Ayuda/components/ApproverAllTickets.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Clock, ListChecks, User } from "lucide-react";
+import moment from "moment";
+import "moment/locale/es";
+import { useEffect, useState } from "react";
+import { parseCategoryFromTitle } from "../constants/categories";
+import { statusFor } from "../constants/ticket-status";
+import { ApproverAllTicketsSkeleton } from "../fallback/ApproverAllTicketsSkeleton";
+import { APPROVER_ALL_PAGE_SIZE, useApproverTicketsPage } from "../hooks/useApproverTickets";
+import { PageFetchBar, PaginationNav } from "./PaginationNav";
+import { TicketPriorityBadge } from "./TicketPriorityBadge";
+
+interface Props {
+  /** Abre el detalle del ticket (mismo handler que la lista principal). */
+  onSelect?: (id: number) => void;
+}
+
+/**
+ * Vista auditora del aprobador: TODOS los tickets del proyecto (de todos los
+ * usuarios) con quién los generó, estado y prioridad. Paginación server-side,
+ * más recientes primero. El backend decide qué incluye (externos + internos
+ * valorizados) y solo responde a aprobadores; para el resto la lista viene
+ * vacía y el panel no se renderiza.
+ */
+export function ApproverAllTickets({ onSelect }: Props) {
+  const [page, setPage] = useState(1);
+  const { data, isLoading, isPlaceholderData } = useApproverTicketsPage(page);
+
+  const tickets = data?.tickets ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / APPROVER_ALL_PAGE_SIZE));
+
+  // Si el total baja (se borraron tickets), corregimos la página actual.
+  // El setState reacciona a datos nuevos del server (sistema externo) y está
+  // guardado por condición: corre a lo sumo una vez por cambio de total.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
+  // Primera carga: skeleton con las mismas dimensiones que el panel real.
+  if (isLoading) return <ApproverAllTicketsSkeleton />;
+
+  if (total === 0) return null;
+
+  const showPagination = total > APPROVER_ALL_PAGE_SIZE;
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="border-b">
+        <CardTitle className="flex items-center gap-2">
+          <ListChecks className="h-5 w-5 text-muted-foreground" />
+          Todos los tickets del proyecto
+          <Badge variant="secondary" className="font-medium">
+            {total}
+          </Badge>
+        </CardTitle>
+        <CardDescription>
+          Vista de aprobador: reportes de todos los usuarios y quién los generó.
+        </CardDescription>
+      </CardHeader>
+      <PageFetchBar active={isPlaceholderData} />
+      <CardContent className="divide-y p-0">
+        {/* Durante la transición de página los datos salientes quedan atenuados
+            y sin interacción; key={page} monta la entrante con fade-in. */}
+        <div
+          key={page}
+          aria-busy={isPlaceholderData}
+          className={`divide-y animate-in fade-in-25 duration-300 transition-[opacity,filter] ${
+            isPlaceholderData ? "pointer-events-none opacity-50 saturate-50" : ""
+          }`}
+        >
+          {tickets.map((ticket) => {
+            const status = statusFor(ticket.status?.slug, ticket.status?.name);
+            const { cleanTitle, categoryLabel } = parseCategoryFromTitle(ticket.title);
+            const reporterLabel =
+              ticket.reporter_name && ticket.reporter_name.trim() !== ""
+                ? ticket.reporter_name
+                : (ticket.reporter_email ?? "Desconocido");
+
+            return (
+              <button
+                key={ticket.id}
+                type="button"
+                onClick={() => onSelect?.(ticket.id)}
+                className="flex w-full cursor-pointer flex-wrap items-center justify-between gap-3 px-6 py-3.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`inline-flex h-2 w-2 shrink-0 rounded-full ${status.dotClass}`}
+                    />
+                    <p className="truncate text-sm font-medium">
+                      TKT-{ticket.id} · {cleanTitle}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <span className="inline-flex items-center gap-1">
+                      <User className="h-3 w-3" />
+                      {reporterLabel}
+                    </span>
+                    {categoryLabel && <span>{categoryLabel}</span>}
+                    <span className="inline-flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {moment(ticket.created_at).locale("es").fromNow()}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <TicketPriorityBadge slug={ticket.priority} />
+                  <Badge variant="outline" className={`border-transparent ${status.badgeClass}`}>
+                    {status.label}
+                  </Badge>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {showPagination && (
+          <PaginationNav
+            page={page}
+            total={total}
+            pageSize={APPROVER_ALL_PAGE_SIZE}
+            onPageChange={setPage}
+            isFetching={isPlaceholderData}
+            ariaLabel="Paginación de tickets del proyecto"
+            className="px-6 py-3"
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/Ayuda/components/ApproverInbox.tsx
+++ b/src/features/Ayuda/components/ApproverInbox.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useQueryClient } from "@tanstack/react-query";
+import { Clock, Loader2, ShieldCheck, Tag, User } from "lucide-react";
+import moment from "moment";
+import "moment/locale/es";
+import { toast } from "sonner";
+import type { Ticket } from "@/shared/lib/taskapp/types";
+import { parseCategoryFromTitle } from "../constants/categories";
+import { ApproverInboxSkeleton } from "../fallback/ApproverInboxSkeleton";
+import { useApproveTicket } from "../hooks/useApproveTicket";
+import { usePendingApproverTickets, APPROVER_TICKETS_QUERY_KEY } from "../hooks/useApproverTickets";
+import { useRejectTicket } from "../hooks/useRejectTicket";
+import { TicketPriorityBadge } from "./TicketPriorityBadge";
+
+interface Props {
+  /** Abre el detalle del ticket (mismo handler que la lista principal). */
+  onSelect?: (id: number) => void;
+}
+
+/**
+ * Bandeja del aprobador: lista los tickets pendientes de aprobación del cliente.
+ * No renderiza nada si el usuario no es aprobador o no hay nada pendiente, así que
+ * es seguro montarla siempre dentro del Centro de Ayuda.
+ */
+export function ApproverInbox({ onSelect }: Props) {
+  const { data: pending = [], isLoading } = usePendingApproverTickets();
+
+  // Primera carga: skeleton con las mismas dimensiones que la bandeja real.
+  if (isLoading) return <ApproverInboxSkeleton />;
+
+  if (pending.length === 0) return null;
+
+  return (
+    <Card className="overflow-hidden border-l-4 border-l-yellow-500">
+      <CardHeader className="border-b">
+        <CardTitle className="flex items-center gap-2">
+          <ShieldCheck className="h-5 w-5 text-yellow-600" />
+          Pendientes de tu aprobación
+          <Badge variant="secondary" className="font-medium">
+            {pending.length}
+          </Badge>
+        </CardTitle>
+        <CardDescription>
+          Aprobá o rechazá estos tickets para que el equipo pueda avanzar.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="divide-y p-0">
+        {pending.map((ticket) => (
+          <ApproverRow key={ticket.id} ticket={ticket} onSelect={onSelect} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ApproverRow({ ticket, onSelect }: { ticket: Ticket; onSelect?: (id: number) => void }) {
+  const queryClient = useQueryClient();
+  const approve = useApproveTicket(ticket.id);
+  const reject = useRejectTicket(ticket.id);
+  const isBusy = approve.isPending || reject.isPending;
+
+  function refresh() {
+    queryClient.invalidateQueries({ queryKey: APPROVER_TICKETS_QUERY_KEY });
+  }
+
+  async function handleApprove() {
+    try {
+      await approve.mutateAsync();
+      toast.success("Aprobación registrada.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Error al aprobar");
+    } finally {
+      // Refrescar siempre: si otro aprobador ya resolvió el ticket (carrera),
+      // el pendiente desaparece de la bandeja igual.
+      refresh();
+    }
+  }
+
+  async function handleReject() {
+    try {
+      await reject.mutateAsync();
+      toast.success("Rechazo registrado.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Error al rechazar");
+    } finally {
+      refresh();
+    }
+  }
+
+  const { cleanTitle, categoryLabel, categoryDef } = parseCategoryFromTitle(ticket.title);
+  const CategoryIcon = categoryDef?.icon ?? Tag;
+  const reporterLabel =
+    ticket.reporter_name && ticket.reporter_name.trim() !== ""
+      ? ticket.reporter_name
+      : (ticket.reporter_email ?? "Desconocido");
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 px-6 py-4">
+      <button
+        type="button"
+        onClick={() => onSelect?.(ticket.id)}
+        className="min-w-0 flex-1 cursor-pointer space-y-1.5 rounded-md text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-2 w-2 shrink-0 rounded-full bg-yellow-500" />
+          <p className="truncate text-sm font-semibold">
+            TKT-{ticket.id} · {cleanTitle}
+          </p>
+        </div>
+        {ticket.description && (
+          <p className="line-clamp-1 text-xs text-muted-foreground">{ticket.description}</p>
+        )}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <User className="h-3 w-3" />
+            {reporterLabel}
+          </span>
+          {categoryLabel && (
+            <span className="inline-flex items-center gap-1">
+              <CategoryIcon className="h-3 w-3" />
+              {categoryLabel}
+            </span>
+          )}
+          <span className="inline-flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            {moment(ticket.created_at).locale("es").fromNow()}
+          </span>
+        </div>
+      </button>
+      <div className="flex shrink-0 items-center gap-2">
+        <TicketPriorityBadge slug={ticket.priority} />
+        <Button variant="outline" size="sm" onClick={handleReject} disabled={isBusy}>
+          Rechazar
+        </Button>
+        <Button size="sm" onClick={handleApprove} disabled={isBusy}>
+          {isBusy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Aprobar
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/Ayuda/components/HelpCenter.tsx
+++ b/src/features/Ayuda/components/HelpCenter.tsx
@@ -6,9 +6,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { CheckCircle2, Clock, HelpCircle, Inbox, Loader2, RefreshCcw } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Ticket, TicketWithUnread } from "@/shared/lib/taskapp/types";
-import { useMyTicketsWithUnread } from "../hooks/useMyTicketsWithUnread";
+import { useMyTicketsPage } from "../hooks/useMyTicketsPage";
+import { ApproverAllTickets } from "./ApproverAllTickets";
+import { ApproverInbox } from "./ApproverInbox";
 import { MyTicketsList } from "./MyTicketsList";
 import { TicketForm } from "./TicketForm";
 
@@ -18,26 +20,6 @@ interface Stats {
   total: number;
   active: number;
   resolved: number;
-}
-
-const ACTIVE_SLUGS = new Set([
-  "open",
-  "in_progress",
-  "planned",
-  "pending_planning",
-  "valued",
-  "blocked",
-]);
-const RESOLVED_SLUGS = new Set(["resolved", "done", "closed", "cancelled"]);
-
-function computeStats(tickets: TicketWithUnread[]): Stats {
-  const stats: Stats = { total: tickets.length, active: 0, resolved: 0 };
-  for (const t of tickets) {
-    const slug = t.status?.slug;
-    if (slug && RESOLVED_SLUGS.has(slug)) stats.resolved += 1;
-    else if (slug && ACTIVE_SLUGS.has(slug)) stats.active += 1;
-  }
-  return stats;
 }
 
 interface Props {
@@ -56,8 +38,33 @@ export function HelpCenter({
   currentUserName,
 }: Props) {
   const searchParams = useSearchParams();
-  const { data: tickets = [], isFetching, refetch } = useMyTicketsWithUnread(initialTickets);
-  const stats = useMemo(() => computeStats(tickets), [tickets]);
+
+  // "Mis tickets" paginado server-side; los totales del backend alimentan las
+  // estadísticas del hero sin traer toda la lista.
+  const [myPage, setMyPage] = useState(1);
+  const {
+    data: myTicketsPage,
+    isLoading: myTicketsLoading,
+    isFetching,
+    isPlaceholderData: myTicketsTransition,
+    refetch,
+  } = useMyTicketsPage(myPage, initialTickets);
+  const tickets = myTicketsPage?.tickets ?? [];
+  const ticketsTotal = myTicketsPage?.total ?? 0;
+  const ticketsCompleted = myTicketsPage?.completed ?? 0;
+  const stats: Stats = {
+    total: ticketsTotal,
+    active: Math.max(0, ticketsTotal - ticketsCompleted),
+    resolved: ticketsCompleted,
+  };
+
+  // Al crear un ticket nuevo (sube el total), volvemos a página 1 para que el
+  // usuario lo vea primerito.
+  const prevTotal = useRef(ticketsTotal);
+  useEffect(() => {
+    if (ticketsTotal > prevTotal.current && myPage !== 1) setMyPage(1);
+    prevTotal.current = ticketsTotal;
+  }, [ticketsTotal, myPage]);
 
   // Estado local para apertura instantánea del Sheet — mismo patrón que TabsManagerClient.
   // Evita el round-trip al server cada vez que el usuario clickea una card.
@@ -104,13 +111,18 @@ export function HelpCenter({
     <section className="space-y-6 pt-2">
       <HelpHero stats={stats} />
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+      <ApproverInbox onSelect={handleSelect} />
+
+      {/* Alturas unificadas por grid stretch: el form (altura natural, sin
+          scroll) define la altura de la fila y la card de tickets se estira a
+          esa misma altura. La lista pagina de a pocos para no cortar cards. */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:items-stretch">
         <Card className="overflow-hidden">
           <TicketForm />
         </Card>
 
-        <Card className="overflow-hidden">
-          <CardHeader className="border-b flex flex-row items-center justify-between gap-3">
+        <Card className="overflow-hidden lg:flex lg:flex-col">
+          <CardHeader className="border-b flex flex-row items-center justify-between gap-3 shrink-0">
             <div className="space-y-1 min-w-0">
               <CardTitle className="flex items-center gap-2">
                 <Inbox className="h-5 w-5 text-muted-foreground" />
@@ -139,15 +151,22 @@ export function HelpCenter({
               </Button>
             </div>
           </CardHeader>
-          <CardContent className="pt-6">
+          <CardContent className="pt-6 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:overflow-hidden">
             <MyTicketsList
               tickets={tickets}
+              total={ticketsTotal}
+              page={myPage}
+              onPageChange={setMyPage}
               activeTicketId={activeTicketId}
               onSelect={handleSelect}
+              isLoading={myTicketsLoading && !myTicketsPage}
+              isPageTransition={myTicketsTransition}
             />
           </CardContent>
         </Card>
       </div>
+
+      <ApproverAllTickets onSelect={handleSelect} />
 
       <TicketDetailSheet
         ticketId={activeTicketId}

--- a/src/features/Ayuda/components/MyTicketsList.tsx
+++ b/src/features/Ayuda/components/MyTicketsList.tsx
@@ -1,116 +1,89 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useRef } from "react";
 import type { TicketWithUnread } from "@/shared/lib/taskapp/types";
+import { MyTicketsListSkeleton } from "../fallback/MyTicketsListSkeleton";
+import { MY_TICKETS_PAGE_SIZE } from "../hooks/useMyTicketsPage";
 import { EmptyTicketsState } from "./EmptyTicketsState";
+import { PageFetchBar, PaginationNav } from "./PaginationNav";
 import { TicketCard } from "./TicketCard";
 
-const PAGE_SIZE = 10;
-
 interface Props {
+  /** Tickets de la página actual (paginados server-side, más recientes primero). */
   tickets: TicketWithUnread[];
+  /** Total de tickets sin paginar (para la navegación). */
+  total: number;
+  page: number;
+  onPageChange: (page: number) => void;
   activeTicketId: number | null;
   onSelect: (id: number) => void;
+  /** Primera carga sin datos: muestra el skeleton dedicado. */
+  isLoading?: boolean;
+  /** Página nueva en viaje (keepPreviousData): atenúa la saliente + barra. */
+  isPageTransition?: boolean;
 }
 
-export function MyTicketsList({ tickets, activeTicketId, onSelect }: Props) {
-  const sorted = useMemo(
-    () => [...tickets].sort((a, b) => b.created_at.localeCompare(a.created_at)),
-    [tickets]
-  );
-
-  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
-  const [page, setPage] = useState(1);
-  const previousCount = useRef(sorted.length);
-  const previousFirstId = useRef<number | null>(sorted[0]?.id ?? null);
+export function MyTicketsList({
+  tickets,
+  total,
+  page,
+  onPageChange,
+  activeTicketId,
+  onSelect,
+  isLoading,
+  isPageTransition = false,
+}: Props) {
   const listRef = useRef<HTMLDivElement | null>(null);
 
-  // Si aparece un ticket nuevo (el primero de la lista cambia o crece), saltamos a página 1
-  // para garantizar que el usuario vea su nuevo ticket "primerito".
-  useEffect(() => {
-    const firstId = sorted[0]?.id ?? null;
-    const isNewer = sorted.length > previousCount.current || firstId !== previousFirstId.current;
-    if (isNewer && page !== 1) {
-      setPage(1);
-    }
-    previousCount.current = sorted.length;
-    previousFirstId.current = firstId;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sorted]);
+  if (isLoading) return <MyTicketsListSkeleton />;
+  if (total === 0) return <EmptyTicketsState />;
 
-  // Si el total de páginas disminuye (ej. el backend cambió la cantidad), corregimos page.
-  useEffect(() => {
-    if (page > totalPages) setPage(totalPages);
-  }, [page, totalPages]);
-
-  if (sorted.length === 0) {
-    return <EmptyTicketsState />;
-  }
-
-  const start = (page - 1) * PAGE_SIZE;
-  const visible = sorted.slice(start, start + PAGE_SIZE);
-  const showPagination = sorted.length > PAGE_SIZE;
+  const showPagination = total > MY_TICKETS_PAGE_SIZE;
 
   function goTo(next: number) {
-    setPage(next);
+    onPageChange(next);
     listRef.current?.scrollTo({ top: 0, behavior: "smooth" });
   }
 
   return (
-    <div className="space-y-4">
+    <div className="flex h-full flex-col gap-3">
+      <PageFetchBar active={isPageTransition} />
+
       <div
         ref={listRef}
         // px-1 da espacio para la sombra del hover sin chocar con el scrollbar.
         // pb-3 evita que la última card aparezca pegada al borde inferior del Card padre.
-        className="flex flex-col gap-3 max-h-[70vh] overflow-y-auto px-1 pb-3"
+        // En desktop la card padre fija la altura: la lista llena el espacio y
+        // scrollea internamente (lg:flex-1). En mobile cae al tope de 70vh.
+        // Durante la transición de página la lista saliente queda atenuada y
+        // sin interacción hasta que llega la nueva (sin parpadeo ni skeleton).
+        className={`flex flex-col gap-3 max-h-[70vh] overflow-y-auto px-1 pb-3 lg:max-h-none lg:flex-1 lg:min-h-0 transition-[opacity,filter] duration-200 ${
+          isPageTransition ? "pointer-events-none opacity-50 saturate-50" : ""
+        }`}
+        aria-busy={isPageTransition}
       >
-        {visible.map((t) => (
-          <TicketCard key={t.id} ticket={t} onClick={onSelect} isActive={activeTicketId === t.id} />
-        ))}
+        {/* key={page}: la página entrante se monta con su animación de entrada. */}
+        <div key={page} className="flex flex-col gap-3 animate-in fade-in-25 duration-300">
+          {tickets.map((t) => (
+            <TicketCard
+              key={t.id}
+              ticket={t}
+              onClick={onSelect}
+              isActive={activeTicketId === t.id}
+            />
+          ))}
+        </div>
       </div>
 
       {showPagination && (
-        <nav
-          className="flex items-center justify-between gap-3 border-t pt-3"
-          aria-label="Paginación"
-        >
-          <p className="text-xs text-muted-foreground tabular-nums">
-            Mostrando{" "}
-            <span className="font-medium text-foreground">
-              {start + 1}–{Math.min(start + PAGE_SIZE, sorted.length)}
-            </span>{" "}
-            de <span className="font-medium text-foreground">{sorted.length}</span>
-          </p>
-          <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="h-7 w-7"
-              onClick={() => goTo(page - 1)}
-              disabled={page === 1}
-              aria-label="Página anterior"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <span className="px-2 text-xs font-medium tabular-nums text-muted-foreground">
-              {page} / {totalPages}
-            </span>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="h-7 w-7"
-              onClick={() => goTo(page + 1)}
-              disabled={page === totalPages}
-              aria-label="Página siguiente"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
-        </nav>
+        <PaginationNav
+          page={page}
+          total={total}
+          pageSize={MY_TICKETS_PAGE_SIZE}
+          onPageChange={goTo}
+          isFetching={isPageTransition}
+          className="mt-auto shrink-0 border-t pt-3"
+        />
       )}
     </div>
   );

--- a/src/features/Ayuda/components/PaginationNav.tsx
+++ b/src/features/Ayuda/components/PaginationNav.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
+
+interface PaginationNavProps {
+  page: number;
+  total: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  /** Hay una página nueva en viaje: spinner + botones bloqueados. */
+  isFetching?: boolean;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Navegación de paginación server-side compartida por las listas del módulo.
+ * Mientras llega la página nueva muestra un spinner junto al contador y
+ * bloquea los botones (evita dobles clicks y requests pisadas), sin mover
+ * ni un píxel del layout.
+ */
+export function PaginationNav({
+  page,
+  total,
+  pageSize,
+  onPageChange,
+  isFetching = false,
+  ariaLabel = "Paginación",
+  className = "",
+}: PaginationNavProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const start = (page - 1) * pageSize;
+
+  return (
+    <nav
+      className={`flex items-center justify-between gap-3 ${className}`}
+      aria-label={ariaLabel}
+      aria-busy={isFetching}
+    >
+      <p className="flex items-center gap-2 text-xs text-muted-foreground tabular-nums">
+        {/* El spinner ocupa el lugar reservado por el gap: sin layout shift. */}
+        <span className="inline-flex h-3 w-3 items-center justify-center" aria-hidden>
+          {isFetching && <Loader2 className="h-3 w-3 animate-spin text-primary" />}
+        </span>
+        Mostrando{" "}
+        <span className="font-medium text-foreground">
+          {Math.min(start + 1, total)}–{Math.min(start + pageSize, total)}
+        </span>{" "}
+        de <span className="font-medium text-foreground">{total}</span>
+      </p>
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page === 1 || isFetching}
+          aria-label="Página anterior"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <span className="px-2 text-xs font-medium tabular-nums text-muted-foreground">
+          {page} / {totalPages}
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page === totalPages || isFetching}
+          aria-label="Página siguiente"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </nav>
+  );
+}
+
+/**
+ * Barra de progreso indeterminada (estilo GitHub/YouTube) para transiciones de
+ * página. Reserva siempre su alto (h-0.5) y solo togglea opacidad: cero layout
+ * shift. Usa el color primary del proyecto host.
+ */
+export function PageFetchBar({ active }: { active: boolean }) {
+  return (
+    <div
+      role="progressbar"
+      aria-hidden={!active}
+      aria-label="Cargando página"
+      className={`relative h-0.5 w-full shrink-0 overflow-hidden rounded-full transition-opacity duration-200 ${
+        active ? "bg-primary/15 opacity-100" : "opacity-0"
+      }`}
+    >
+      {active && (
+        <span
+          className="absolute inset-y-0 w-1/3 rounded-full bg-primary"
+          style={{ animation: "taskapp-page-fetch 0.9s ease-in-out infinite" }}
+        />
+      )}
+      <style>{`@keyframes taskapp-page-fetch { 0% { left: -33%; } 100% { left: 100%; } }`}</style>
+    </div>
+  );
+}

--- a/src/features/Ayuda/components/detail/TicketApprovalBanner.tsx
+++ b/src/features/Ayuda/components/detail/TicketApprovalBanner.tsx
@@ -16,6 +16,7 @@ import { Loader2, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import type { Ticket } from "@/shared/lib/taskapp/types";
 import { useApproveTicket } from "../../hooks/useApproveTicket";
+import { usePendingApproverTickets } from "../../hooks/useApproverTickets";
 import { useRejectTicket } from "../../hooks/useRejectTicket";
 
 interface Props {
@@ -24,8 +25,14 @@ interface Props {
 }
 
 export function TicketApprovalBanner({ ticket, currentUserEmail }: Props) {
-  const isApprover = ticket.approver_email != null && ticket.approver_email === currentUserEmail;
-  const canApprove = isApprover && ticket.status?.slug === "valued";
+  void currentUserEmail;
+  // Solo los aprobadores reales ven las acciones: el listado de pendientes lo
+  // resuelve el backend validando el email contra el array de aprobadores del
+  // proyecto (un no-aprobador recibe lista vacía). Un aprobador puede aprobar
+  // cualquier ticket pendiente, incluso los creados por él mismo.
+  const { data: pendingTickets = [] } = usePendingApproverTickets();
+  const isApprover = pendingTickets.some((t) => t.id === ticket.id);
+  const canApprove = isApprover && ticket.status?.slug === "pendiente_aprobacion";
 
   const approve = useApproveTicket(ticket.id);
   const reject = useRejectTicket(ticket.id);
@@ -58,12 +65,10 @@ export function TicketApprovalBanner({ ticket, currentUserEmail }: Props) {
         <div className="flex items-start gap-3">
           <ShieldCheck className="mt-0.5 h-5 w-5 text-amber-600" />
           <div>
-            <p className="text-sm font-medium">Te pidieron aprobar esta valuación</p>
-            {ticket.estimated_hours != null && (
-              <p className="text-xs text-muted-foreground">
-                Estimación: <strong>{ticket.estimated_hours} hs</strong>
-              </p>
-            )}
+            <p className="text-sm font-medium">Este ticket necesita tu aprobación</p>
+            <p className="text-xs text-muted-foreground">
+              Aprobalo para que el equipo pueda avanzar, o rechazalo si no corresponde.
+            </p>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -75,10 +80,9 @@ export function TicketApprovalBanner({ ticket, currentUserEmail }: Props) {
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
-                <AlertDialogTitle>¿Confirmás que rechazás esta valuación?</AlertDialogTitle>
+                <AlertDialogTitle>¿Confirmás que rechazás este ticket?</AlertDialogTitle>
                 <AlertDialogDescription>
-                  Al rechazar, el ticket vuelve a planificación para revisar el alcance o el
-                  esfuerzo.
+                  Al rechazar, el ticket queda cancelado y el equipo no avanzará con él.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>

--- a/src/features/Ayuda/components/detail/TicketDetailSheet.tsx
+++ b/src/features/Ayuda/components/detail/TicketDetailSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import type { Ticket } from "@/shared/lib/taskapp/types";
 import { Inbox } from "lucide-react";
 import { useEffect } from "react";
@@ -42,7 +42,13 @@ export default function TicketDetailSheet({
 
   return (
     <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
-      <SheetContent side="right" className="sm:max-w-2xl flex flex-col p-0 gap-0">
+      <SheetContent
+        side="right"
+        className="sm:max-w-2xl flex flex-col p-0 gap-0"
+        aria-describedby={undefined}
+      >
+        {/* Titulo accesible para lectores de pantalla (Radix exige un DialogTitle) */}
+        <SheetTitle className="sr-only">{ticket ? ticket.title : "Detalle del ticket"}</SheetTitle>
         {isLoading && !ticket ? (
           <TicketDetailSheetSkeleton />
         ) : ticket ? (

--- a/src/features/Ayuda/constants/ticket-status.ts
+++ b/src/features/Ayuda/constants/ticket-status.ts
@@ -14,6 +14,20 @@ export const STATUS_BY_SLUG: Record<string, StatusDef> = {
     dotClass: "bg-blue-500",
     tintClass: "from-blue-500/10",
   },
+  pendiente_aprobacion: {
+    label: "Pendiente de aprobación",
+    badgeClass: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    borderClass: "border-l-yellow-500",
+    dotClass: "bg-yellow-500",
+    tintClass: "from-yellow-500/10",
+  },
+  aprobado_cliente: {
+    label: "Aprobado",
+    badgeClass: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    borderClass: "border-l-green-500",
+    dotClass: "bg-green-500",
+    tintClass: "from-green-500/10",
+  },
   in_progress: {
     label: "En curso",
     badgeClass: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",

--- a/src/features/Ayuda/fallback/ApproverAllTicketsSkeleton.tsx
+++ b/src/features/Ayuda/fallback/ApproverAllTicketsSkeleton.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Mismas dimensiones que ApproverAllTickets: card con header (título +
+ * descripción) y filas de la misma altura que las reales (dos líneas + badges).
+ */
+export function ApproverAllTicketsSkeleton() {
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="border-b">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="h-5 w-64" />
+          <Skeleton className="h-5 w-8 rounded-full" />
+        </div>
+        <Skeleton className="mt-1.5 h-4 w-96 max-w-full" />
+      </CardHeader>
+      <CardContent className="divide-y p-0">
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="flex flex-wrap items-center justify-between gap-3 px-6 py-3.5">
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-2 w-2 rounded-full" />
+                <Skeleton className="h-4 w-1/2" />
+              </div>
+              <Skeleton className="h-3 w-2/5" />
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/Ayuda/fallback/ApproverInboxSkeleton.tsx
+++ b/src/features/Ayuda/fallback/ApproverInboxSkeleton.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Mismas dimensiones que ApproverInbox (card con borde amarillo, header con
+ * título+descripción y una fila con meta + botones de acción).
+ */
+export function ApproverInboxSkeleton() {
+  return (
+    <Card className="overflow-hidden border-l-4 border-l-yellow-500/40">
+      <CardHeader className="border-b">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="h-5 w-56" />
+          <Skeleton className="h-5 w-8 rounded-full" />
+        </div>
+        <Skeleton className="mt-1.5 h-4 w-80 max-w-full" />
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="flex flex-wrap items-center justify-between gap-3 px-6 py-4">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="h-3 w-2/5" />
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/Ayuda/fallback/MyTicketsListSkeleton.tsx
+++ b/src/features/Ayuda/fallback/MyTicketsListSkeleton.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export function MyTicketsListSkeleton() {
   return (
     <div className="flex flex-col gap-3">
-      {[0, 1, 2].map((i) => (
+      {[0, 1, 2, 3].map((i) => (
         <Card key={i} className="p-4 border-l-4 border-l-muted">
           <div className="flex items-start justify-between gap-3">
             <Skeleton className="h-5 w-3/5" />

--- a/src/features/Ayuda/hooks/useApproveTicket.ts
+++ b/src/features/Ayuda/hooks/useApproveTicket.ts
@@ -2,7 +2,9 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { approveSupportTicket } from "../actions/support-approval";
+import { APPROVER_TICKETS_QUERY_KEY } from "./useApproverTickets";
 import { MY_TICKETS_QUERY_KEY } from "./useMyTickets";
+import { MY_TICKETS_PAGE_QUERY_KEY } from "./useMyTicketsPage";
 import { ticketDetailKey } from "./useTicketDetail";
 
 export function useApproveTicket(ticketId: number) {
@@ -12,6 +14,8 @@ export function useApproveTicket(ticketId: number) {
     onSuccess: (updated) => {
       queryClient.setQueryData(ticketDetailKey(ticketId), updated);
       queryClient.invalidateQueries({ queryKey: MY_TICKETS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: MY_TICKETS_PAGE_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: APPROVER_TICKETS_QUERY_KEY });
     },
   });
 }

--- a/src/features/Ayuda/hooks/useApproverTickets.ts
+++ b/src/features/Ayuda/hooks/useApproverTickets.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { getApproverTicketsPage, getPendingApproverTickets } from "../actions/support-approval";
+
+/** Prefijo común: invalidar esto refresca pendientes y todas las páginas. */
+export const APPROVER_TICKETS_QUERY_KEY = ["taskapp", "approver-tickets"];
+
+export const APPROVER_ALL_PAGE_SIZE = 10;
+
+/**
+ * Página de la vista auditora del aprobador (server-side, más recientes
+ * primero). Para no-aprobadores el backend devuelve vacío y la UI se oculta.
+ */
+export function useApproverTicketsPage(page: number) {
+  return useQuery({
+    queryKey: [...APPROVER_TICKETS_QUERY_KEY, "all", page],
+    queryFn: () => getApproverTicketsPage(page, APPROVER_ALL_PAGE_SIZE),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Tickets pendientes de aprobación del cliente. Alimenta la bandeja del
+ * aprobador y el gate del banner de aprobación en el detalle.
+ */
+export function usePendingApproverTickets() {
+  return useQuery({
+    queryKey: [...APPROVER_TICKETS_QUERY_KEY, "pending"],
+    queryFn: () => getPendingApproverTickets(),
+    staleTime: 30_000,
+  });
+}

--- a/src/features/Ayuda/hooks/useCreateTicket.ts
+++ b/src/features/Ayuda/hooks/useCreateTicket.ts
@@ -2,7 +2,10 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createSupportTicket } from "../actions/support-tickets";
+import { APPROVER_TICKETS_QUERY_KEY } from "./useApproverTickets";
 import { MY_TICKETS_QUERY_KEY } from "./useMyTickets";
+import { MY_TICKETS_PAGE_QUERY_KEY } from "./useMyTicketsPage";
+import { MY_TICKETS_WITH_UNREAD_QUERY_KEY } from "./useMyTicketsWithUnread";
 
 export function useCreateTicket() {
   const queryClient = useQueryClient();
@@ -10,6 +13,9 @@ export function useCreateTicket() {
     mutationFn: createSupportTicket,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: MY_TICKETS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: MY_TICKETS_PAGE_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: MY_TICKETS_WITH_UNREAD_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: APPROVER_TICKETS_QUERY_KEY });
     },
   });
 }

--- a/src/features/Ayuda/hooks/useMarkTicketAsReadMutation.ts
+++ b/src/features/Ayuda/hooks/useMarkTicketAsReadMutation.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { markSupportTicketAsRead } from "../actions/support-ticket-views";
+import { MY_TICKETS_PAGE_QUERY_KEY } from "./useMyTicketsPage";
 import { MY_TICKETS_WITH_UNREAD_QUERY_KEY } from "./useMyTicketsWithUnread";
 
 export function useMarkTicketAsReadMutation() {
@@ -10,6 +11,7 @@ export function useMarkTicketAsReadMutation() {
     mutationFn: (ticketId: number) => markSupportTicketAsRead(ticketId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: MY_TICKETS_WITH_UNREAD_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: MY_TICKETS_PAGE_QUERY_KEY });
     },
   });
 }

--- a/src/features/Ayuda/hooks/useMyTicketsPage.ts
+++ b/src/features/Ayuda/hooks/useMyTicketsPage.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import type { TicketWithUnread } from "@/shared/lib/taskapp/types";
+import { getMyTicketsPageWithUnread, type MyTicketsPage } from "../actions/support-tickets";
+
+/** Prefijo: invalidarlo refresca todas las páginas de "Mis tickets". */
+export const MY_TICKETS_PAGE_QUERY_KEY = ["ayuda", "my-tickets-page"];
+
+export const MY_TICKETS_PAGE_SIZE = 4;
+
+const RESOLVED_SLUGS = new Set(["resolved", "done", "closed", "cancelled"]);
+
+/**
+ * Página de "Mis tickets" (server-side, más recientes primero) con no-leídos.
+ * `initialTickets` (la lista del SSR de la page) siembra la página 1 para que
+ * el primer render no muestre skeleton.
+ */
+export function useMyTicketsPage(page: number, initialTickets?: TicketWithUnread[]) {
+  return useQuery({
+    queryKey: [...MY_TICKETS_PAGE_QUERY_KEY, page],
+    queryFn: () => getMyTicketsPageWithUnread(page, MY_TICKETS_PAGE_SIZE),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+    initialData:
+      page === 1 && initialTickets
+        ? ({
+            tickets: initialTickets.slice(0, MY_TICKETS_PAGE_SIZE),
+            total: initialTickets.length,
+            completed: initialTickets.filter((t) => {
+              const slug = t.status?.slug;
+              return !!slug && RESOLVED_SLUGS.has(slug);
+            }).length,
+          } satisfies MyTicketsPage)
+        : undefined,
+  });
+}

--- a/src/features/Ayuda/hooks/useRejectTicket.ts
+++ b/src/features/Ayuda/hooks/useRejectTicket.ts
@@ -2,7 +2,9 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { rejectSupportTicket } from "../actions/support-approval";
+import { APPROVER_TICKETS_QUERY_KEY } from "./useApproverTickets";
 import { MY_TICKETS_QUERY_KEY } from "./useMyTickets";
+import { MY_TICKETS_PAGE_QUERY_KEY } from "./useMyTicketsPage";
 import { ticketDetailKey } from "./useTicketDetail";
 
 export function useRejectTicket(ticketId: number) {
@@ -12,6 +14,8 @@ export function useRejectTicket(ticketId: number) {
     onSuccess: (updated) => {
       queryClient.setQueryData(ticketDetailKey(ticketId), updated);
       queryClient.invalidateQueries({ queryKey: MY_TICKETS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: MY_TICKETS_PAGE_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: APPROVER_TICKETS_QUERY_KEY });
     },
   });
 }

--- a/src/features/Ayuda/hooks/useRequestTicketReopen.ts
+++ b/src/features/Ayuda/hooks/useRequestTicketReopen.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { requestSupportTicketReopen } from "../actions/support-reopen";
 import { MY_TICKETS_QUERY_KEY } from "./useMyTickets";
+import { MY_TICKETS_PAGE_QUERY_KEY } from "./useMyTicketsPage";
 import { ticketDetailKey } from "./useTicketDetail";
 import { MY_TICKETS_WITH_UNREAD_QUERY_KEY } from "./queryKeys";
 
@@ -15,6 +16,7 @@ export function useRequestTicketReopen(ticketId: number) {
       queryClient.setQueryData(ticketDetailKey(ticketId), updatedTicket);
       queryClient.invalidateQueries({ queryKey: MY_TICKETS_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: MY_TICKETS_WITH_UNREAD_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: MY_TICKETS_PAGE_QUERY_KEY });
     },
   });
 }

--- a/src/features/Ayuda/hooks/useSupportTicketsRealtimeSync.ts
+++ b/src/features/Ayuda/hooks/useSupportTicketsRealtimeSync.ts
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { MY_TICKETS_WITH_UNREAD_QUERY_KEY } from "./useMyTicketsWithUnread";
+import { MY_TICKETS_PAGE_QUERY_KEY } from "./useMyTicketsPage";
+import { APPROVER_TICKETS_QUERY_KEY } from "./useApproverTickets";
 import type { TaskAppRealtimeEvent } from "@/shared/lib/taskapp/types";
 import { Logger } from "@/lib/logger";
 
@@ -24,17 +26,29 @@ export function useSupportTicketsRealtimeSync() {
     source.onmessage = (msg) => {
       try {
         const event = JSON.parse(msg.data) as TaskAppRealtimeEvent;
-        if (event.type === "ticket.updated" || event.type === "comment.created") {
+        if (
+          event.type === "ticket.created" ||
+          event.type === "ticket.updated" ||
+          event.type === "comment.created"
+        ) {
           queryClient.invalidateQueries({ queryKey: MY_TICKETS_WITH_UNREAD_QUERY_KEY });
+          queryClient.invalidateQueries({ queryKey: MY_TICKETS_PAGE_QUERY_KEY });
+          queryClient.invalidateQueries({ queryKey: APPROVER_TICKETS_QUERY_KEY });
         }
       } catch (error) {
         logger.warn("Failed to parse SSE event", { data: { error } });
       }
     };
 
+    // Refetch de cortesía al reconectar, THROTTLEADO: si el SSE falla en loop
+    // (backend caído, rate limit), invalidar en cada error genera una tormenta
+    // de requests que agrava el problema. Como máximo un refetch cada 15s.
+    let lastErrorRefetch = 0;
     source.onerror = () => {
-      // EventSource reintenta solo. Refetch de cortesía por si perdimos eventos.
       logger.debug("SSE error / reconnecting");
+      const now = Date.now();
+      if (now - lastErrorRefetch < 15_000) return;
+      lastErrorRefetch = now;
       queryClient.invalidateQueries({ queryKey: MY_TICKETS_WITH_UNREAD_QUERY_KEY });
     };
 

--- a/src/features/Ayuda/types/index.ts
+++ b/src/features/Ayuda/types/index.ts
@@ -8,6 +8,8 @@ export type { PriorityDef, PrioritySlug } from "../constants/ticket-priority";
 export interface ReporterIdentity {
   email: string;
   name: string | null;
+  /** ID estable del usuario en auth. Usado como FK en support_ticket_views. */
+  userId: string;
 }
 
 export interface CreateSupportTicketInput {

--- a/src/shared/lib/taskapp/client.ts
+++ b/src/shared/lib/taskapp/client.ts
@@ -58,6 +58,73 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   }
 }
 
+export interface PagedTickets {
+  tickets: Ticket[];
+  /** Total de tickets sin paginar (header X-Total-Count). */
+  total: number;
+  /** Cuántos del total están en un estado completado (header X-Completed-Count). */
+  completed: number;
+}
+
+export interface PageOpts {
+  limit?: number;
+  offset?: number;
+  /** Filtro opcional por slug de estado (solo for-approver). */
+  status?: string;
+}
+
+function pageQuery(opts?: PageOpts): string {
+  const params = new URLSearchParams();
+  if (opts?.limit && opts.limit > 0) {
+    params.set("limit", String(opts.limit));
+    params.set("offset", String(opts.offset ?? 0));
+  }
+  if (opts?.status) params.set("status", opts.status);
+  const qs = params.toString();
+  return qs ? `&${qs}` : "";
+}
+
+/** Como request(), pero además lee los headers de totales para paginación. */
+async function requestPaged(path: string): Promise<PagedTickets> {
+  const url = `${baseURL()}/api/public/v1${path}`;
+  const key = apiKey();
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { "Content-Type": "application/json", "X-Project-Key": key },
+      cache: "no-store",
+    });
+  } catch (error) {
+    if (error instanceof TaskAppError) throw error;
+    logger.error("taskApp network error", { data: { url, error } });
+    throw new TaskAppError(0, "network", error instanceof Error ? error.message : "network error");
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    logger.error("taskApp request failed", { data: { url, status: res.status, body } });
+    throw new TaskAppError(res.status, "http", body || res.statusText);
+  }
+
+  let tickets: Ticket[];
+  try {
+    tickets = (await res.json()) as Ticket[];
+  } catch (error) {
+    logger.error("taskApp invalid JSON", { data: { url, error } });
+    throw new TaskAppError(res.status, "parse", "invalid JSON");
+  }
+
+  // Backends viejos no mandan los headers: degradamos al length de la página.
+  const total = Number(res.headers.get("X-Total-Count") ?? tickets.length);
+  const completed = Number(res.headers.get("X-Completed-Count") ?? 0);
+  return {
+    tickets,
+    total: Number.isFinite(total) ? total : tickets.length,
+    completed: Number.isFinite(completed) ? completed : 0,
+  };
+}
+
 async function requestMultipart<T>(path: string, formData: FormData): Promise<T> {
   const url = `${baseURL()}${path}`;
   const key = apiKey();
@@ -93,8 +160,18 @@ export const taskAppClient = {
   createTicket: (body: CreateTicketRequest) =>
     request<Ticket>("/tickets", { method: "POST", body: JSON.stringify(body) }),
 
-  listTicketsByReporter: (reporterEmail: string) =>
-    request<Ticket[]>(`/tickets?reporter_email=${encodeURIComponent(reporterEmail)}`),
+  // Tickets del reporter, más recientes primero. Con opts.limit pagina
+  // server-side y devuelve los totales en PagedTickets.
+  listTicketsByReporter: (reporterEmail: string, opts?: PageOpts) =>
+    requestPaged(`/tickets?reporter_email=${encodeURIComponent(reporterEmail)}${pageQuery(opts)}`),
+
+  // Listado para un aprobador: todos los TKT externos del proyecto + los internos
+  // ya valorizados, más recientes primero. Requiere que el email sea uno de los
+  // aprobadores del proyecto. Soporta paginación server-side y filtro por estado.
+  listTicketsForApprover: (approverEmail: string, opts?: PageOpts) =>
+    requestPaged(
+      `/tickets/for-approver?approver_email=${encodeURIComponent(approverEmail)}${pageQuery(opts)}`
+    ),
 
   getTicketById: (id: number) => request<Ticket>(`/tickets/${id}`),
 

--- a/src/shared/lib/taskapp/types.ts
+++ b/src/shared/lib/taskapp/types.ts
@@ -21,6 +21,7 @@ export interface Ticket {
   status_id: number;
   status?: TicketStatus;
   priority: TicketPriority;
+  origin?: "internal" | "external";
   reporter_email: string | null;
   reporter_name: string | null;
   approver_email: string | null;
@@ -29,6 +30,7 @@ export interface Ticket {
   created_at: string;
   updated_at: string;
   resolved_at: string | null;
+  valorized_at: string | null;
   labels: TicketLabel[];
   reopen_status: "pending" | null;
   reopen_reason: string | null;
@@ -65,8 +67,9 @@ export interface UploadResult {
 
 export type TaskAppRealtimeEvent =
   | { type: "connected" }
-  | { type: "ticket.updated"; ticket_id: number }
-  | { type: "comment.created"; ticket_id: number };
+  | { type: "ticket.created"; id: number }
+  | { type: "ticket.updated"; id: number }
+  | { type: "comment.created"; id: number };
 
 export interface TicketUnreadState {
   hasStatusChange: boolean;


### PR DESCRIPTION
## Resumen

Actualiza el módulo de Ayuda (tickets de soporte) a la versión nueva del instalador de TaskApp:

- **Flujo de aprobación cliente**: bandeja de pendientes para aprobadores (aprobar/rechazar) y vista auditora con todos los tickets del proyecto y quién los generó.
- **Paginación server-side** en "Mis tickets" y "Todos los tickets" (más recientes primero), con transición de página, skeletons dedicados y totales del backend.
- **Accesibilidad**: título accesible (DialogTitle) en el sheet de detalle del ticket.
- Manifest de instalación (`.taskapp-cli-manifest.json`) para futuras actualizaciones inteligentes.

Se preservan las integraciones propias del proyecto: adapter de Clerk (`getReporterEmail`), shim de prisma y logger de pino.

## Pruebas realizadas (local, contra base dev)

- Login con usuario de prueba de Clerk y navegación al dashboard.
- Item "Ayuda" en el sidebar con badge de no leídos.
- Creación de ticket → llegó al backend de TaskApp.
- Realtime SSE: cambio de estado y comentario del agente actualizan la card y el badge sin recargar.
- Marcar como leído al abrir el detalle limpia el badge.
- `tsc --noEmit` sin errores; ESLint sin errores.

## Requisito de deploy

Antes de probar en el ambiente deployado, agregar en Dokploy (prod y dev):

- `TASKAPP_BASE_URL`
- `TASKAPP_PROJECT_API_KEY`