### PR TITLE
Mostrar horas valorizadas en la aprobacion del cliente

### DIFF
--- a/src/features/Ayuda/components/ApproverInbox.tsx
+++ b/src/features/Ayuda/components/ApproverInbox.tsx
@@ -129,6 +129,12 @@ function ApproverRow({ ticket, onSelect }: { ticket: Ticket; onSelect?: (id: num
             <Clock className="h-3 w-3" />
             {moment(ticket.created_at).locale("es").fromNow()}
           </span>
+          {ticket.estimated_hours != null && (
+            <span className="inline-flex items-center gap-1 font-medium text-amber-700 dark:text-amber-400">
+              <Clock className="h-3 w-3" />
+              {ticket.estimated_hours} h valorizadas
+            </span>
+          )}
         </div>
       </button>
       <div className="flex shrink-0 items-center gap-2">

--- a/src/features/Ayuda/components/detail/TicketApprovalBanner.tsx
+++ b/src/features/Ayuda/components/detail/TicketApprovalBanner.tsx
@@ -65,10 +65,16 @@ export function TicketApprovalBanner({ ticket, currentUserEmail }: Props) {
         <div className="flex items-start gap-3">
           <ShieldCheck className="mt-0.5 h-5 w-5 text-amber-600" />
           <div>
-            <p className="text-sm font-medium">Este ticket necesita tu aprobación</p>
+            <p className="text-sm font-medium">Aprobá la valorización de este ticket</p>
             <p className="text-xs text-muted-foreground">
-              Aprobalo para que el equipo pueda avanzar, o rechazalo si no corresponde.
+              El equipo valorizó este ticket. Aprobá para que pase a planificación, o rechazalo si
+              no corresponde.
             </p>
+            {ticket.estimated_hours != null && (
+              <p className="mt-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+                Horas valorizadas: {ticket.estimated_hours} h
+              </p>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
El cliente ahora aprueba la valorizacion del ticket (no su creacion). El banner y la bandeja del aprobador muestran las horas valorizadas. Acompana el nuevo flujo de valorizacion/aprobacion de TaskApp.