### PR TITLE
fix(inspecciones): serve inspection images from R2 by env bucket

### DIFF
--- a/src/app/api/inspecciones/file/[id]/route.ts
+++ b/src/app/api/inspecciones/file/[id]/route.ts
@@ -1,0 +1,39 @@
+import prisma from "@/lib/db";
+import { getBytesFromR2 } from "@/lib/r2-upload";
+import { contentTypeFromKey } from "@/lib/mime";
+import { apiLogger } from "@/lib/logger";
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const imagen = await prisma.inspeccionRespuestaImagen.findUnique({
+    where: { id },
+    select: { r2Key: true },
+  });
+
+  if (!imagen) {
+    return new Response("Imagen no encontrada", { status: 404 });
+  }
+
+  try {
+    const file = await getBytesFromR2(imagen.r2Key);
+    if (!file) {
+      return new Response("Archivo no encontrado", { status: 404 });
+    }
+
+    const contentType =
+      file.contentType && file.contentType !== "application/octet-stream"
+        ? file.contentType
+        : contentTypeFromKey(imagen.r2Key);
+
+    const headers = new Headers();
+    headers.set("Content-Type", contentType);
+    headers.set("Content-Disposition", "inline");
+    headers.set("Cache-Control", "private, max-age=3600");
+
+    return new Response(Buffer.from(file.bytes), { headers });
+  } catch (error) {
+    apiLogger.error({ error, imagenId: id, key: imagen.r2Key }, "Error al obtener imagen de R2");
+    return new Response("Error al obtener el archivo", { status: 500 });
+  }
+}

--- a/src/components/inspecciones/components/inspeccion-form.tsx
+++ b/src/components/inspecciones/components/inspeccion-form.tsx
@@ -337,7 +337,6 @@ export function InspeccionForm({ inspeccionId }: Props) {
             onSave={handleSave}
             savingIds={savingIds}
             formularioId={inspeccionId}
-            r2PublicBase="https://pub-f585ac1b3c1f462c8439adaf03fa21cd.r2.dev"
             onImageUploaded={handleImageUploaded}
             onImageDeleted={handleImageDeleted}
           />

--- a/src/components/inspecciones/components/inspeccion-pregunta.tsx
+++ b/src/components/inspecciones/components/inspeccion-pregunta.tsx
@@ -54,7 +54,6 @@ type Props = {
   ) => void;
   savingIds: Set<string>;
   formularioId: string;
-  r2PublicBase: string;
   onImageUploaded: (preguntaId: string, imagen: ImagenLocal) => void;
   onImageDeleted: (preguntaId: string, imagenId: string) => void;
 };
@@ -69,7 +68,6 @@ export function InspeccionPregunta({
   onSave,
   savingIds,
   formularioId,
-  r2PublicBase,
   onImageUploaded,
   onImageDeleted,
 }: Props) {
@@ -254,7 +252,7 @@ export function InspeccionPregunta({
                     className="block overflow-hidden rounded-md border focus:outline-none focus:ring-2 focus:ring-primary"
                   >
                     <img
-                      src={`${r2PublicBase}/${img.r2Key}`}
+                      src={`/api/inspecciones/file/${img.id}`}
                       alt={`Adjunto ${idx + 1}`}
                       className="h-20 w-20 object-cover transition-transform hover:scale-105"
                     />
@@ -384,7 +382,7 @@ export function InspeccionPregunta({
                     onTouchEnd={() => setDragging(false)}
                   >
                     <img
-                      src={`${r2PublicBase}/${imagenes[lightboxIndex]?.r2Key}`}
+                      src={`/api/inspecciones/file/${imagenes[lightboxIndex]?.id}`}
                       alt={`Imagen ${lightboxIndex + 1} de ${imagenes.length}`}
                       className="max-h-[75vh] max-w-[85vw] select-none object-contain transition-transform duration-150"
                       style={{
@@ -468,7 +466,6 @@ export function InspeccionPregunta({
               onSave={onSave}
               savingIds={savingIds}
               formularioId={formularioId}
-              r2PublicBase={r2PublicBase}
               onImageUploaded={onImageUploaded}
               onImageDeleted={onImageDeleted}
             />

--- a/src/components/inspecciones/components/inspeccion-seccion.tsx
+++ b/src/components/inspecciones/components/inspeccion-seccion.tsx
@@ -30,7 +30,6 @@ type Props = {
   ) => void;
   savingIds: Set<string>;
   formularioId: string;
-  r2PublicBase: string;
   onImageUploaded: (preguntaId: string, imagen: ImagenLocal) => void;
   onImageDeleted: (preguntaId: string, imagenId: string) => void;
 };
@@ -68,7 +67,6 @@ export function InspeccionSeccion({
   onSave,
   savingIds,
   formularioId,
-  r2PublicBase,
   onImageUploaded,
   onImageDeleted,
 }: Props) {
@@ -106,7 +104,6 @@ export function InspeccionSeccion({
             onSave={onSave}
             savingIds={savingIds}
             formularioId={formularioId}
-            r2PublicBase={r2PublicBase}
             onImageUploaded={onImageUploaded}
             onImageDeleted={onImageDeleted}
           />
@@ -122,7 +119,6 @@ export function InspeccionSeccion({
             onSave={onSave}
             savingIds={savingIds}
             formularioId={formularioId}
-            r2PublicBase={r2PublicBase}
             onImageUploaded={onImageUploaded}
             onImageDeleted={onImageDeleted}
           />

--- a/src/components/inspecciones/components/pdf-actions.ts
+++ b/src/components/inspecciones/components/pdf-actions.ts
@@ -6,10 +6,10 @@ import { PERMISSIONS } from "@/lib/rbac/permissions";
 import { pdfLogger } from "@/lib/logger";
 import { formatDateOnly } from "@/lib/dates";
 import { inspeccionRepository } from "@/repositories/inspeccion.repository";
+import { getBytesFromR2 } from "@/lib/r2-upload";
+import { contentTypeFromKey } from "@/lib/mime";
 import { getSeccionesConPreguntas } from "./actions";
 import { InspeccionPDF, type SeccionPDF, type PreguntaPDF } from "../pdf/InspeccionPDF";
-
-const R2_PUBLIC_BASE = "https://pub-f585ac1b3c1f462c8439adaf03fa21cd.r2.dev";
 
 const TIPO_LABEL: Record<string, string> = {
   inspeccion_base: "Inspección de Base",
@@ -87,17 +87,43 @@ export async function generateInspeccionPDF(inspeccionId: string) {
       }
     }
 
-    // Detalle de hallazgos (respuestas NO)
-    const detallesNo = inspeccion.respuestas
+    // Detalle de hallazgos (respuestas NO). Las imágenes se descargan de R2
+    // (bucket correcto por entorno) y se embeben como data URI base64, para no
+    // depender de una URL pública (que en producción apunta a otro bucket).
+    const detallesNoOrdenadas = inspeccion.respuestas
       .filter((r) => r.valor === "no")
-      .map((r) => ({
+      .sort((a, b) =>
+        a.pregunta.codigo.localeCompare(b.pregunta.codigo, undefined, { numeric: true })
+      );
+
+    const detallesNo = await Promise.all(
+      detallesNoOrdenadas.map(async (r) => ({
         codigo: r.pregunta.codigo,
         texto: r.pregunta.texto,
         acciones: r.accionesSeleccionadas.map((a) => a.accion.texto),
         observaciones: r.observaciones,
-        imagenesUrls: r.imagenes.map((img) => `${R2_PUBLIC_BASE}/${img.r2Key}`),
+        imagenesUrls: (
+          await Promise.all(
+            r.imagenes.map(async (img) => {
+              const file = await getBytesFromR2(img.r2Key);
+              if (!file) {
+                pdfLogger.warn(
+                  { r2Key: img.r2Key, inspeccionId },
+                  "Imagen de inspección no encontrada en R2; se omite en el PDF"
+                );
+                return null;
+              }
+              const contentType =
+                file.contentType && file.contentType !== "application/octet-stream"
+                  ? file.contentType
+                  : contentTypeFromKey(img.r2Key);
+              const base64 = Buffer.from(file.bytes).toString("base64");
+              return `data:${contentType};base64,${base64}`;
+            })
+          )
+        ).filter((url): url is string => url !== null),
       }))
-      .sort((a, b) => a.codigo.localeCompare(b.codigo, undefined, { numeric: true }));
+    );
 
     const lugar = inspeccion.clientLocation?.name ?? inspeccion.lugarTexto ?? "—";
 

--- a/src/lib/__tests__/mime.test.ts
+++ b/src/lib/__tests__/mime.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { contentTypeFromKey } from "../mime";
+
+describe("contentTypeFromKey", () => {
+  it("maps jpg and jpeg to image/jpeg", () => {
+    expect(contentTypeFromKey("inspecciones/a/b/1.jpg")).toBe("image/jpeg");
+    expect(contentTypeFromKey("inspecciones/a/b/1.jpeg")).toBe("image/jpeg");
+  });
+
+  it("maps png to image/png", () => {
+    expect(contentTypeFromKey("inspecciones/a/b/1.png")).toBe("image/png");
+  });
+
+  it("maps webp to image/webp", () => {
+    expect(contentTypeFromKey("x/1.webp")).toBe("image/webp");
+  });
+
+  it("is case-insensitive with the extension", () => {
+    expect(contentTypeFromKey("x/1.JPG")).toBe("image/jpeg");
+  });
+
+  it("falls back to application/octet-stream for unknown or missing extension", () => {
+    expect(contentTypeFromKey("x/noext")).toBe("application/octet-stream");
+    expect(contentTypeFromKey("x/file.heic")).toBe("application/octet-stream");
+  });
+});

--- a/src/lib/mime.ts
+++ b/src/lib/mime.ts
@@ -1,0 +1,16 @@
+/**
+ * Infiere el content-type de imagen a partir de la extensión de una key de R2.
+ * Se usa como fallback cuando R2 no devuelve un ContentType confiable.
+ */
+const EXT_TO_CONTENT_TYPE: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+  gif: "image/gif",
+};
+
+export function contentTypeFromKey(key: string): string {
+  const ext = key.split(".").pop()?.toLowerCase() ?? "";
+  return EXT_TO_CONTENT_TYPE[ext] ?? "application/octet-stream";
+}

--- a/src/lib/r2-upload.ts
+++ b/src/lib/r2-upload.ts
@@ -1,6 +1,11 @@
 "use server";
 
-import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
 import { env } from "./env";
 
 const r2Client = new S3Client({
@@ -37,6 +42,31 @@ export async function deleteFileFromR2(key: string): Promise<void> {
       Key: key,
     })
   );
+}
+
+/**
+ * Descarga los bytes de un objeto de R2 (bucket configurado por entorno).
+ * Devuelve null si el objeto no existe o hubo error, para que el llamador
+ * decida cómo manejarlo (ej: omitir la imagen en el PDF).
+ */
+export async function getBytesFromR2(
+  key: string
+): Promise<{ bytes: Uint8Array; contentType: string } | null> {
+  try {
+    const result = await r2Client.send(
+      new GetObjectCommand({
+        Bucket: env.CLOUDFLARE_R2_BUCKET,
+        Key: key,
+      })
+    );
+
+    if (!result.Body) return null;
+
+    const bytes = await result.Body.transformToByteArray();
+    return { bytes, contentType: result.ContentType ?? "application/octet-stream" };
+  } catch {
+    return null;
+  }
 }
 
 export async function uploadBytesToR2(


### PR DESCRIPTION
Inspection images used a hardcoded dev R2 public URL, so in production (images live in a different bucket) they 404'd and showed as empty boxes in the PDF and UI thumbnails (ticket #396).

- add getBytesFromR2 helper and contentTypeFromKey (unit tested)
- PDF: download images from R2 via the S3 client (env bucket) and embed them as base64 data URIs instead of a public URL; missing objects are logged and skipped
- add /api/inspecciones/file/[id] route and serve UI thumbnails/lightbox through it, removing the hardcoded public URL from the components