### PR TITLE
feat(inspecciones): compress inspection images client-side before upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.18",
         "@types/moment": "^2.11.29",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -8084,6 +8085,15 @@
         "base64-js": "^1.1.2"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
@@ -14855,6 +14865,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.18",
     "@types/moment": "^2.11.29",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/inspecciones/components/inspeccion-pregunta.tsx
+++ b/src/components/inspecciones/components/inspeccion-pregunta.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { uploadImagenRespuesta, deleteImagenRespuesta } from "./inspeccion-actions";
+import { compressImage } from "@/lib/compress-image";
 
 export type PreguntaData = {
   id: string;
@@ -59,7 +60,9 @@ type Props = {
 };
 
 const MAX_IMAGENES = 3;
-const MAX_FILE_SIZE_MB = 15;
+// Tamaño máximo del ORIGINAL aceptado. Se comprime en el cliente antes de subir,
+// así que lo que finalmente se guarda pesa ~1.5 MB independientemente de esto.
+const MAX_FILE_SIZE_MB = 50;
 
 export function InspeccionPregunta({
   pregunta,
@@ -98,6 +101,8 @@ export function InspeccionPregunta({
 
   const isSaving = savingIds.has(pregunta.id);
 
+  const [preparing, setPreparing] = useState(false);
+
   const uploadMutation = useMutation({
     mutationFn: (formData: FormData) => uploadImagenRespuesta(formData),
     onSuccess: (data) => {
@@ -121,22 +126,29 @@ export function InspeccionPregunta({
   });
 
   const handleFileChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
+    async (e: ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
+      e.target.value = "";
       if (!file) return;
 
       if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
         toast.error(`La imagen supera el tamaño máximo de ${MAX_FILE_SIZE_MB} MB`);
-        e.target.value = "";
         return;
+      }
+
+      setPreparing(true);
+      let toUpload = file;
+      try {
+        toUpload = await compressImage(file);
+      } finally {
+        setPreparing(false);
       }
 
       const formData = new FormData();
       formData.set("formularioId", formularioId);
       formData.set("preguntaId", pregunta.id);
-      formData.set("file", file);
+      formData.set("file", toUpload);
       uploadMutation.mutate(formData);
-      e.target.value = "";
     },
     [formularioId, pregunta.id, uploadMutation]
   );
@@ -295,21 +307,25 @@ export function InspeccionPregunta({
                   type="button"
                   variant="outline"
                   size="sm"
-                  disabled={uploadMutation.isPending}
+                  disabled={uploadMutation.isPending || preparing}
                   onClick={() => cameraInputRef.current?.click()}
                 >
-                  {uploadMutation.isPending ? (
+                  {uploadMutation.isPending || preparing ? (
                     <Loader2 className="mr-1 h-3 w-3 animate-spin" />
                   ) : (
                     <Camera className="mr-1 h-3 w-3" />
                   )}
-                  {uploadMutation.isPending ? "Subiendo..." : "Tomar foto"}
+                  {preparing
+                    ? "Procesando..."
+                    : uploadMutation.isPending
+                      ? "Subiendo..."
+                      : "Tomar foto"}
                 </Button>
                 <Button
                   type="button"
                   variant="outline"
                   size="sm"
-                  disabled={uploadMutation.isPending}
+                  disabled={uploadMutation.isPending || preparing}
                   onClick={() => fileInputRef.current?.click()}
                 >
                   <Paperclip className="mr-1 h-3 w-3" />

--- a/src/lib/compress-image.ts
+++ b/src/lib/compress-image.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import imageCompression from "browser-image-compression";
+
+/**
+ * Comprime/redimensiona una imagen en el navegador antes de subirla.
+ *
+ * Acepta originales grandes (fotos de celular de hasta ~50 MB) y las reduce a
+ * un tamaño razonable para documentación (máx ~2560px de lado, ~1.5 MB),
+ * respetando la orientación EXIF. Corre en un web worker para no bloquear la UI.
+ *
+ * Si el archivo no es una imagen o la compresión falla, devuelve el original.
+ */
+const DEFAULT_OPTIONS = {
+  maxSizeMB: 1.5,
+  maxWidthOrHeight: 2560,
+  useWebWorker: true,
+  initialQuality: 0.8,
+};
+
+export async function compressImage(file: File): Promise<File> {
+  if (!file.type.startsWith("image/")) return file;
+
+  try {
+    const compressed = await imageCompression(file, DEFAULT_OPTIONS);
+    // Garantizamos un File con nombre y tipo consistentes.
+    return new File([compressed], file.name, {
+      type: compressed.type || file.type,
+      lastModified: Date.now(),
+    });
+  } catch {
+    return file;
+  }
+}


### PR DESCRIPTION
The client asked to accept images up to 50MB. Instead of storing huge raw photos, accept large originals (up to 50MB) but resize/compress them in the browser before upload (max ~2560px, ~1.5MB, EXIF-orientation aware) via browser-image-compression. This keeps uploads fast, storage cheap and PDFs light, and stays well under the server action body limit.