### PR TITLE
fix(auth): add missing /sign-up route and fix invitation redirect

### DIFF
--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,5 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function Page() {
+  return <SignUp />;
+}

--- a/src/components/usuarios/components/actions.ts
+++ b/src/components/usuarios/components/actions.ts
@@ -52,7 +52,12 @@ export async function createUserAction(data: CreateUserPayload): Promise<void> {
   try {
     await client.invitations.createInvitation({
       emailAddress: email,
-      redirectUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard`,
+      // Debe apuntar a una página que renderice <SignUp />: ahí se consume el
+      // __clerk_ticket de la invitación. Apuntar a /dashboard no funciona
+      // porque está protegido y el middleware rebota al invitado a /sign-in,
+      // perdiendo el ticket. El redirect post-alta lo maneja
+      // NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL (/dashboard).
+      redirectUrl: `${env.NEXT_PUBLIC_APP_URL}/sign-up`,
       publicMetadata: {
         role: role.name,
       },


### PR DESCRIPTION
The app never had a /sign-up page, yet NEXT_PUBLIC_CLERK_SIGN_UP_URL (/sign-up) is inlined into the client bundle, so Clerk <SignIn /> rendered a "Registrate" footer link pointing at a 404 — both on /sign-in and in the landing SignInButton modal.

Invitations were broken too: createInvitation used /dashboard as redirectUrl, but that route is protected, so the middleware bounced invitees to /sign-in and the __clerk_ticket was lost. Clerk requires the redirect target to render <SignUp /> to consume the ticket, which means invited users could never complete registration.

Requires setting sign-up mode to "Restricted" in the Clerk Dashboard, otherwise /sign-up now allows public self-registration with the default "lectura" role.